### PR TITLE
Fix Typescript compilation issues and Allow Sidebar Scrolling

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -11,10 +11,15 @@ body {
 
 .sidebar {
   width: 240px;
-  min-height: 100vh;
   box-shadow: 6px 0 6px rgba(0, 0, 0, 0.1);
   position: fixed;
   top: 64px;
+  bottom: 0;
+}
+
+.sidebar > ul {
+  overflow-x: scroll;
+  height: 100%;
 }
 
 h1 {

--- a/src/examples/Buildings3D.tsx
+++ b/src/examples/Buildings3D.tsx
@@ -33,7 +33,7 @@ const Building3d: React.FC = () => {
         </div>
         <div style={{height: '400px'}}>
             <AzureMapsProvider>
-                <AzureMap options={option} styleOptions={{showBuildingModels: showBuildingModels}} >
+                <AzureMap options={{...option, showBuildingModels }}>
                 </AzureMap>
             </AzureMapsProvider>
         </div>

--- a/src/examples/MultiplePointWithPopup.tsx
+++ b/src/examples/MultiplePointWithPopup.tsx
@@ -123,7 +123,9 @@ const MarkersExample: React.FC = () => {
                 }}
                 type="SymbolLayer"
               />
-              {memoizedMarkerRender}
+              <>
+                {memoizedMarkerRender}
+              </>
             </AzureMapDataSourceProvider>
             <AzureMapPopup
               isVisible={true}


### PR DESCRIPTION
As it is the project no longer compiles. 

* style options were merged into `IAzureMapOptions`
* memoizedMarkerRender producing essentially JSX.Element[] need to be wrapped inside a fragment to compile.

Additionally, sidebar scrolling was added so that the bottom examples can be accessible. 